### PR TITLE
Create base Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:11-jdk-slim-buster AS builder
+
+WORKDIR /app
+COPY * /app/
+COPY .mvn/ /app/.mvn/
+RUN ./mvnw -B package --file pom.xml
+
+FROM openjdk:11-jre-slim-buster
+
+WORKDIR /app
+COPY --from=builder /app/target/database-query-runner-1.0-SNAPSHOT.jar /app


### PR DESCRIPTION
Adds a simple, initial Dockerfile capable of running the
Maven build and copying the resulting JAR file to the final
Docker image using OpenJDK 11 on a slim Buster base.