### PR TITLE
Caches Maven dependencies during CI runs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,14 +8,27 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: '11'
+
+    - name: Cache Maven packages
+      id: cache-maven-packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: maven-repo-cache-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          maven-repo-cache-
+
+    - name: Download Maven Dependencies
+      if: steps.cache-maven-packages.outputs.cache-hit != 'true'
+      run: ./mvnw dependency:go-offline
+
     - name: Build with Maven
-      run: ./mvnw -B package --file pom.xml
+      run: ./mvnw -o package

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,15 @@
     <version>1.0-SNAPSHOT</version>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Enables the GitHub cache action to re-use downloaded Maven
artifacts from previous CI runs.

This should greatly speed up the majority of CI runs by
skipping subsequent downloads from the Maven repositories.